### PR TITLE
fix: 2. Fast Api 하위에 FastAPI 실전 시리즈 배치 및 사이드바 전체 펼침

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -28,9 +28,27 @@ const sidebars: SidebarsConfig = {
                             id: 'study/tech/test-container'
                         },
                         {
-                            type: 'doc',
+                            type: 'category',
                             label: '2. Fast Api',
-                            id: 'study/tech/fast-api'
+                            collapsed: false,
+                            link: {
+                                type: 'doc',
+                                id: 'study/tech/fast-api'
+                            },
+                            items: [
+                                {
+                                    type: 'category',
+                                    label: '2-1. FastAPI 실전 시리즈',
+                                    collapsed: false,
+                                    items: [
+                                        {
+                                            type: 'doc',
+                                            label: '1. Layered Architecture와 DI 패턴',
+                                            id: 'fastapi/series/fast-api-layered'
+                                        }
+                                    ],
+                                },
+                            ]
                         }
                     ],
                 },
@@ -144,25 +162,6 @@ const sidebars: SidebarsConfig = {
                             id: 'study/design_pattern/solid',
                         }
                     ],
-                },
-                {
-                    type: 'category',
-                    label: '2. Fast Api',
-                    collapsed: false,
-                    items: [
-                        {
-                            type: 'category',
-                            label: '2-1. FastAPI 실전 시리즈',
-                            collapsed: false,
-                            items: [
-                                {
-                                    type: 'doc',
-                                    label: '1. Layered Architecture와 DI 패턴',
-                                    id: 'fastapi/series/fast-api-layered'
-                                }
-                            ],
-                        },
-                    ]
                 },
             ]
         },


### PR DESCRIPTION
- 2. Fast Api를 category로 변경, 기존 문서는 link로 연결
- 2. Fast Api 하위에 2-1. FastAPI 실전 시리즈 배치
- 전체 카테고리 `collapsed: false` 적용